### PR TITLE
Fix hardcoded port numbers in service modules (Issue #52)

### DIFF
--- a/lib/constants.nix
+++ b/lib/constants.nix
@@ -45,6 +45,7 @@
     stirling-pdf = 8081;
     karakeep = 8090;
     samba = 445;
+    homeassistant = 8123;
 
     # Network Services
     blocky = 4000;

--- a/modules/nixos/services/downloads/sabnzbd.nix
+++ b/modules/nixos/services/downloads/sabnzbd.nix
@@ -5,7 +5,7 @@
 }:
 with lib; let
   cfg = config.services.sabnzbd;
-  port = 8080;
+  constants = import ../../../../lib/constants.nix;
 in {
   options.services.sabnzbd = {
     url = mkOption {
@@ -27,14 +27,14 @@ in {
           entry = {
             href = "https://${cfg.url}";
             icon = "sabnzbd.svg";
-            siteMonitor = "http://127.0.0.1:${toString port}";
+            siteMonitor = "http://127.0.0.1:${toString constants.ports.sabnzbd}";
           };
         }
       ];
 
       nginx.virtualHosts."${cfg.url}" = {
         locations."/" = {
-          proxyPass = "http://127.0.0.1:${toString port}";
+          proxyPass = "http://127.0.0.1:${toString constants.ports.sabnzbd}";
           proxyWebsockets = true;
         };
       };

--- a/modules/nixos/services/media/jellyfin.nix
+++ b/modules/nixos/services/media/jellyfin.nix
@@ -6,6 +6,7 @@
 }:
 with lib; let
   cfg = config.services.jellyfin;
+  constants = import ../../../../lib/constants.nix;
 in {
   options.services.jellyfin = {
     url = mkOption {
@@ -39,7 +40,7 @@ in {
 
       nginx.virtualHosts."${cfg.url}" = {
         locations."/" = {
-          proxyPass = "http://127.0.0.1:8096";
+          proxyPass = "http://127.0.0.1:${toString constants.ports.jellyfin}";
           proxyWebsockets = true;
         };
       };

--- a/modules/nixos/services/media/plex.nix
+++ b/modules/nixos/services/media/plex.nix
@@ -5,6 +5,7 @@
 }:
 with lib; let
   cfg = config.services.plex;
+  constants = import ../../../../lib/constants.nix;
 in {
   options.services.plex = {
     url = mkOption {
@@ -70,7 +71,7 @@ in {
             proxy_buffering off;
           '';
           locations."/" = {
-            proxyPass = "http://127.0.0.1:32400";
+            proxyPass = "http://127.0.0.1:${toString constants.ports.plex}";
             proxyWebsockets = true;
           };
         };

--- a/modules/nixos/services/monitoring/service-health.nix
+++ b/modules/nixos/services/monitoring/service-health.nix
@@ -6,6 +6,7 @@
 }:
 with lib; let
   cfg = config.services.service-health;
+  constants = import ../../../../lib/constants.nix;
 
   serviceHealthScript = pkgs.writeShellScript "service-health-check" ''
     #!/bin/bash
@@ -79,17 +80,17 @@ with lib; let
       # HTTP health checks for web services
       check_http_service "nginx" "http://localhost" "200"
       check_http_service "prometheus" "http://localhost:9090/-/healthy" "200"
-      check_http_service "grafana" "http://localhost:3000/api/health" "200"
+      check_http_service "grafana" "http://localhost:${toString constants.ports.grafana}/api/health" "200"
 
       # Check alertmanager if enabled
       if ${pkgs.systemd}/bin/systemctl is-enabled --quiet alertmanager >/dev/null 2>&1; then
         check_systemd_service "alertmanager"
-        check_http_service "alertmanager" "http://localhost:9093/-/healthy" "200"
+        check_http_service "alertmanager" "http://localhost:${toString constants.ports.alertmanager}/-/healthy" "200"
       fi
 
       # Check additional services that might be running
       if ${pkgs.systemd}/bin/systemctl list-unit-files --quiet jellyfin.service >/dev/null 2>&1; then
-        check_http_service "jellyfin" "http://localhost:8096/health" "200"
+        check_http_service "jellyfin" "http://localhost:${toString constants.ports.jellyfin}/health" "200"
       fi
 
       # Database connectivity checks

--- a/modules/nixos/services/monitoring/uptime-kuma.nix
+++ b/modules/nixos/services/monitoring/uptime-kuma.nix
@@ -5,6 +5,7 @@
 }:
 with lib; let
   cfg = config.services.uptime-kuma;
+  constants = import ../../../../lib/constants.nix;
 in {
   options.services.uptime-kuma = {
     url = mkOption {
@@ -16,7 +17,7 @@ in {
   config = mkIf cfg.enable {
     services.nginx.virtualHosts."${cfg.url}" = {
       locations."/" = {
-        proxyPass = "http://127.0.0.1:3001";
+        proxyPass = "http://127.0.0.1:${toString constants.ports.uptime-kuma}";
         proxyWebsockets = true;
       };
     };

--- a/modules/nixos/virtualisation/homeassistant.nix
+++ b/modules/nixos/virtualisation/homeassistant.nix
@@ -5,6 +5,7 @@
 }:
 with lib; let
   cfg = config.virtualisation.homeassistant;
+  constants = import ../../../lib/constants.nix;
 in {
   options.virtualisation.homeassistant = with lib.types; {
     enable = mkEnableOption "Whether to enable Home Assistant container.";
@@ -38,7 +39,7 @@ in {
 
     services.nginx.virtualHosts."${cfg.url}" = {
       locations."/" = {
-        proxyPass = "http://127.0.0.1:8123";
+        proxyPass = "http://127.0.0.1:${toString constants.ports.homeassistant}";
         proxyWebsockets = true;
       };
     };


### PR DESCRIPTION
## Summary

- Replace hardcoded port numbers with constants references in 7 service modules
- Add missing homeassistant port constant to lib/constants.nix
- Ensure all port numbers are centralized for better maintainability

## Changes Made

### Modified Files:
- **jellyfin.nix**: Replace hardcoded 8096 with `constants.ports.jellyfin`
- **service-health.nix**: Replace hardcoded 3000, 9093, 8096 with constants
- **sabnzbd.nix**: Replace hardcoded 8080 with `constants.ports.sabnzbd`
- **uptime-kuma.nix**: Replace hardcoded 3001 with `constants.ports.uptime-kuma`
- **plex.nix**: Replace hardcoded 32400 with `constants.ports.plex`
- **homeassistant.nix**: Replace hardcoded 8123 with `constants.ports.homeassistant`
- **constants.nix**: Add homeassistant port = 8123

### Technical Details:
- Added constants import to each affected module
- Used `toString constants.ports.<service>` format for port references
- Maintained exact same port numbers, only changed references

## Test Plan

- [x] Run `just check` - passes with zero errors/warnings
- [x] Test build configuration for thor - builds successfully
- [x] Test build configuration for freya - builds successfully
- [x] Verify no port conflicts in constants.nix
- [x] All affected services maintain same functionality

## Impact

✅ **Benefits:**
- Prevents port conflicts through centralized management
- Improves maintainability of service configurations
- Eliminates configuration drift between modules
- Single source of truth for all port assignments

⚠️ **Risk Assessment:** Low
- Simple find/replace operation with existing constants
- No functional changes to service behavior
- All ports remain identical to previous values

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)