### PR TITLE
Standardize service module structure and options (Issue #54)

### DIFF
--- a/docs/service-module-template.md
+++ b/docs/service-module-template.md
@@ -1,0 +1,176 @@
+# Service Module Template
+
+This document provides standardized patterns for creating consistent service modules in the nilfheim configuration.
+
+## Standard Service Module Structure
+
+```nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.SERVICE_NAME;
+  constants = import ../../../../lib/constants.nix;
+in {
+  options.services.SERVICE_NAME = {
+    # Standard URL option for proxy services
+    url = mkOption {
+      type = types.str;
+      default = "SERVICE_NAME.${config.homelab.domain}";
+      description = "URL for SERVICE_NAME proxy host.";
+    };
+
+    # Standard port option (if service needs custom port)
+    port = mkOption {
+      type = types.port;
+      default = constants.ports.SERVICE_NAME;
+      description = "Port for SERVICE_NAME service to listen on.";
+    };
+
+    # Add service-specific options here with proper descriptions
+    customOption = mkOption {
+      type = types.str;
+      default = "defaultValue";
+      description = "Clear explanation of what this option does.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Service configuration
+    services.SERVICE_NAME = {
+      # Service-specific configuration
+    };
+
+    # Homepage dashboard integration
+    services.homepage-dashboard.homelabServices = [
+      {
+        group = "ServiceGroup";
+        name = "Service Name";
+        entry = {
+          href = "https://${cfg.url}";
+          icon = "service-icon.svg";
+          siteMonitor = "https://${cfg.url}";
+          description = "Brief service description";
+        };
+      }
+    ];
+
+    # Nginx proxy configuration
+    services.nginx.virtualHosts."${cfg.url}" = {
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString cfg.port}";
+        inherit (constants.nginxDefaults) proxyWebsockets;
+      };
+    };
+
+    # Additional configuration (firewall, users, etc.)
+  };
+}
+```
+
+## Service Module Patterns
+
+### 1. Basic Service Pattern
+For simple services that only need enable/disable:
+- No custom options needed
+- Use existing NixOS service options
+- Standard homepage integration
+
+### 2. Proxy Service Pattern
+For services behind nginx proxy:
+- Standard `url` option
+- Optional `port` option if configurable
+- Nginx proxy configuration with constants.nginxDefaults
+- Homepage integration
+
+### 3. Complex Service Pattern
+For services with multiple configuration options:
+- Multiple custom options with descriptions
+- Database integration if needed
+- Secret management with agenix
+- Advanced networking/firewall rules
+
+## Required Elements
+
+### Option Descriptions
+Every custom option MUST have a description:
+```nix
+someOption = mkOption {
+  type = types.str;
+  default = "value";
+  description = "Clear explanation of what this option does.";
+};
+```
+
+### Proper Types
+Use appropriate NixOS types:
+- `types.str` for strings
+- `types.port` for ports
+- `types.bool` for booleans
+- `types.int` for integers
+- `types.listOf` for lists
+- `types.path` for filesystem paths
+
+### URL Option Standard
+For services with web interfaces:
+```nix
+url = mkOption {
+  type = types.str;
+  default = "service-name.${config.homelab.domain}";
+  description = "URL for service-name proxy host.";
+};
+```
+
+### Port Option Standard
+For services with configurable ports:
+```nix
+port = mkOption {
+  type = types.port;
+  default = constants.ports.serviceName;
+  description = "Port for service to listen on.";
+};
+```
+
+## Best Practices
+
+### Constants Usage
+- Import constants for ports and common values
+- Use `constants.ports.serviceName` for port defaults
+- Reference `constants.nginxDefaults` for proxy settings
+
+### Naming Conventions
+- Use kebab-case for service names in URLs
+- Use camelCase for constants.ports entries
+- Use descriptive option names
+
+### Documentation
+- Every option needs a clear description
+- Explain what the option affects
+- Include units or constraints where relevant
+
+### Error Prevention
+- Use proper types to catch configuration errors
+- Set sensible defaults
+- Add validation where beneficial
+
+## Examples
+
+### Simple Service (jellyfin.nix)
+```nix
+# Has URL option, uses constants for ports, standard proxy setup
+```
+
+### Complex Service (karakeep.nix)
+```nix
+# Multiple options, port configuration, environment variables
+```
+
+### Service Without Options (code-server.nix - before fix)
+```nix
+# Example of what to avoid - hardcoded values, no options
+```
+
+This template should be used as a reference for maintaining consistency across all service modules.

--- a/modules/nixos/services/downloads/autobrr.nix
+++ b/modules/nixos/services/downloads/autobrr.nix
@@ -5,7 +5,6 @@
 }:
 with lib; let
   cfg = config.services.autobrr;
-  port = "7474";
   constants = import ../../../../lib/constants.nix;
 in {
   options.services.autobrr = {
@@ -13,6 +12,11 @@ in {
       type = types.str;
       default = "autobrr.${config.homelab.domain}";
       description = "URL for autobrr proxy host.";
+    };
+    port = mkOption {
+      type = types.port;
+      default = constants.ports.autobrr;
+      description = "Port for autobrr service to listen on.";
     };
   };
 
@@ -30,14 +34,14 @@ in {
           entry = {
             href = "https://${cfg.url}";
             icon = "autobrr.svg";
-            siteMonitor = "http://127.0.0.1:${toString port}";
+            siteMonitor = "http://127.0.0.1:${toString cfg.port}";
           };
         }
       ];
 
       nginx.virtualHosts."${cfg.url}" = {
         locations."/" = {
-          proxyPass = "http://127.0.0.1:${toString port}";
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
           inherit (constants.nginxDefaults) proxyWebsockets;
         };
       };

--- a/modules/nixos/services/utilities/code-server.nix
+++ b/modules/nixos/services/utilities/code-server.nix
@@ -5,9 +5,16 @@
 }:
 with lib; let
   cfg = config.services.code-server;
-  url = "code-server.${config.homelab.domain}";
   constants = import ../../../../lib/constants.nix;
 in {
+  options.services.code-server = {
+    url = mkOption {
+      type = types.str;
+      default = "code-server.${config.homelab.domain}";
+      description = "URL for code-server proxy host.";
+    };
+  };
+
   config = mkIf cfg.enable {
     services = {
       code-server = {
@@ -19,7 +26,7 @@ in {
         disableFileDownloads = false;
       };
 
-      nginx.virtualHosts."${url}" = {
+      nginx.virtualHosts."${cfg.url}" = {
         locations."/" = {
           proxyPass = "http://127.0.0.1:${toString cfg.port}";
           inherit (constants.nginxDefaults) proxyWebsockets;
@@ -32,9 +39,9 @@ in {
           group = "Utilities";
           name = "Code Server";
           entry = {
-            href = "https://${url}";
+            href = "https://${cfg.url}";
             icon = "vscode.svg";
-            siteMonitor = "https://${url}";
+            siteMonitor = "https://${cfg.url}";
             description = "VS Code in the browser";
           };
         }

--- a/modules/nixos/services/utilities/stirling-pdf.nix
+++ b/modules/nixos/services/utilities/stirling-pdf.nix
@@ -11,10 +11,12 @@ in {
     url = mkOption {
       type = types.str;
       default = "stirling-pdf.${config.homelab.domain}";
+      description = "URL for Stirling PDF proxy host.";
     };
     port = mkOption {
       type = types.port;
       default = 8081;
+      description = "Port for Stirling PDF service to listen on.";
     };
   };
 


### PR DESCRIPTION
## Summary

Implement consistent patterns across service modules to improve maintainability and developer experience. Addresses URL option inconsistencies, missing descriptions, and hardcoded values identified in issue #54.

## Changes Made

### 1. Documentation Template Created
- **docs/service-module-template.md**: Comprehensive guide for consistent service modules
- **3 service patterns**: Basic, Proxy, and Complex service types
- **Best practices**: Option descriptions, types, naming conventions
- **Examples**: Proper URL and port option implementations

### 2. Service Module Standardization

#### code-server.nix
**Before:**
```nix
let
  url = "code-server.${config.homelab.domain}";  # Hardcoded
in {
  config = mkIf cfg.enable {
    nginx.virtualHosts."${url}" = {  # No options block
```

**After:**
```nix
in {
  options.services.code-server = {
    url = mkOption {
      type = types.str;
      default = "code-server.${config.homelab.domain}";
      description = "URL for code-server proxy host.";
    };
  };
  
  config = mkIf cfg.enable {
    nginx.virtualHosts."${cfg.url}" = {  # Uses cfg.url
```

#### stirling-pdf.nix
**Before:**
```nix
url = mkOption {
  type = types.str;
  default = "stirling-pdf.${config.homelab.domain}";
  # No description
};
port = mkOption {
  type = types.port;
  default = 8081;
  # No description
};
```

**After:**
```nix
url = mkOption {
  type = types.str;
  default = "stirling-pdf.${config.homelab.domain}";
  description = "URL for Stirling PDF proxy host.";
};
port = mkOption {
  type = types.port;
  default = 8081;
  description = "Port for Stirling PDF service to listen on.";
};
```

#### autobrr.nix
**Before:**
```nix
let
  port = "7474";  # Hardcoded string
in {
  options.services.autobrr = {
    url = mkOption { ... };
    # No port option
  };
  
  proxyPass = "http://127.0.0.1:${toString port}";
```

**After:**
```nix
in {
  options.services.autobrr = {
    url = mkOption { ... };
    port = mkOption {
      type = types.port;
      default = constants.ports.autobrr;
      description = "Port for autobrr service to listen on.";
    };
  };
  
  proxyPass = "http://127.0.0.1:${toString cfg.port}";
```

## Benefits Achieved

### Code Quality
✅ **Consistent URL options** across all proxy services  
✅ **Proper type validation** using types.port for ports  
✅ **Descriptive documentation** for all custom options  
✅ **Eliminated hardcoded values** in favor of configurable options  

### Developer Experience
✅ **Service module template** provides clear patterns for new services  
✅ **Better error messages** when options are misconfigured  
✅ **Reduced cognitive load** with consistent interfaces  
✅ **Documentation** explains best practices and patterns  

### Maintainability
✅ **Single source of truth** for service configuration patterns  
✅ **Easier debugging** with descriptive option names  
✅ **Future-proof** structure for adding new services  
✅ **No breaking changes** - maintains backward compatibility  

## Testing & Validation

- [x] **Deployed to thor** - Build and deployment successful
- [x] **Linting passed** - Code style validation complete  
- [x] **No functional changes** - All services maintain identical behavior
- [x] **Documentation complete** - Template ready for use

## Files Modified

1. **docs/service-module-template.md** (new) - Service module documentation
2. **modules/nixos/services/utilities/code-server.nix** - Added URL option, removed hardcoded url
3. **modules/nixos/services/utilities/stirling-pdf.nix** - Added missing descriptions
4. **modules/nixos/services/downloads/autobrr.nix** - Proper port option implementation

## Impact

This change establishes a **foundation for consistent service module development** while addressing immediate inconsistencies. The template documentation will guide future service additions and help maintain code quality standards.

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)