### PR TITLE
feat(nixpi): add Raspberry Pi 4 SD card image builder

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,12 @@ freya:
 odin:
     sudo darwin-rebuild switch --flake .#odin
 
+# Build Raspberry Pi SD card image
+nixpi:
+    nix build .#nixosConfigurations.nixpi.config.system.build.sdImage
+    @echo "SD image built: result/sd-image/*.img.zst"
+    @echo "Flash with: zstd -d result/sd-image/*.img.zst -c | sudo dd of=/dev/sdX bs=4M status=progress"
+
 # Run linting tools (formatting, static analysis, dead code detection)
 lint:
     nix fmt .

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       systems =
         if builtins.getEnv "NIX_CHECK_CURRENT_SYSTEM_ONLY" != ""
         then [builtins.currentSystem]
-        else ["x86_64-linux" "x86_64-darwin"];
+        else ["x86_64-linux" "x86_64-darwin" "aarch64-linux"];
 
       imports = [
         ./hosts

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -75,6 +75,12 @@
         hostname = "loki";
         roles = [vps];
       };
+      nixpi = mkNixosSystem {
+        system = "aarch64-linux";
+        hostname = "nixpi";
+        extraModules = [inputs.nixos-hardware.nixosModules.raspberry-pi-4];
+        roles = [];
+      };
       iso = lib.nixosSystem {
         system = "x86_64-linux";
         modules = [

--- a/hosts/nixpi/default.nix
+++ b/hosts/nixpi/default.nix
@@ -1,0 +1,91 @@
+{
+  config,
+  pkgs,
+  modulesPath,
+  lib,
+  ...
+}: {
+  imports = [
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  # Set hostname
+  networking.hostName = "nixpi";
+
+  # Disable impermanence for SD image
+  system.persist.enable = lib.mkForce false;
+
+  # Enable essential services
+  services = {
+    tailscale.enable = true;
+    ssh.enable = true;
+    avahi.enable = true;
+  };
+
+  # Configure SD image
+  sdImage = {
+    compressImage = true;
+    expandOnBoot = true;
+  };
+
+  # Minimal system packages
+  environment.systemPackages = with pkgs; [
+    vim
+    wget
+    curl
+    git
+    htop
+  ];
+
+  # Configure SSH access
+  services.openssh = {
+    settings = {
+      PermitRootLogin = lib.mkForce "yes"; # Allow root login for initial setup
+      PasswordAuthentication = false;
+    };
+  };
+
+  # Configure Tailscale to auto-connect
+  systemd.services.tailscale-autoconnect = {
+    description = "Automatic connection to Tailscale";
+    after = ["network-pre.target" "tailscale.service"];
+    wants = ["network-pre.target" "tailscale.service"];
+    wantedBy = ["multi-user.target"];
+    serviceConfig.Type = "oneshot";
+    script = with pkgs; ''
+      # Wait for tailscale to be ready
+      sleep 5
+
+      # Check if already authenticated
+      status="$(${tailscale}/bin/tailscale status -json | ${jq}/bin/jq -r .BackendState)"
+      if [ $status = "Running" ]; then
+        exit 0
+      fi
+
+      # Authenticate with tailscale using auth key
+      ${tailscale}/bin/tailscale up \
+        --authkey=file:${config.age.secrets.tailscale.path} \
+        --ssh \
+        --accept-routes \
+        --hostname=nixpi
+    '';
+  };
+
+  # Basic network configuration
+  networking = {
+    useDHCP = lib.mkDefault true;
+    interfaces = {};
+    firewall = {
+      enable = true;
+      trustedInterfaces = [config.services.tailscale.interfaceName];
+      allowedUDPPorts = [config.services.tailscale.port];
+      checkReversePath = "loose";
+    };
+  };
+
+  # Set timezone
+  time.timeZone = "Europe/London";
+
+  # Use latest stable kernel
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+}

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -3,7 +3,8 @@ let
   freya = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIO4RjgGmeN0QCTS8V5raJwcoxajuh2K60jtAhw2El1";
   thor = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ4jHnG95Nwr9cauhLD5Aq1PcGk0s9mqfL0YJs/N2fJh";
   loki = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDdktZ+wjrOyIgNiSVRqRCjS/utm5ynpRne9UXsANRa2";
-  systems = [freya odin thor loki];
+  nixpi = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIGCTcs2Smk3y38uu7fhOKKLQ2MafdAyeMvjkJXlB6Jk";
+  systems = [freya odin thor loki nixpi];
   users = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJdf/364Rgul97UR6vn4caDuuxBk9fUrRjfpMsa4sfam ed@freya"
   ];


### PR DESCRIPTION
## Summary

- Add nixpi host configuration for building bootable Raspberry Pi 4 SD card images
- Automatic Tailscale connection on boot with hostname "nixpi"  
- SSH access with same credentials as freya (user: ed)
- SD image compression and auto-expansion

## Features

- **ARM64 Support**: Added aarch64-linux to supported systems
- **Hardware Profile**: Uses nixos-hardware raspberry-pi-4 profile
- **Network**: Tailscale autoconnect systemd service with SSH enabled
- **User Setup**: Same username and password as freya
- **Root Access**: Enabled for initial setup
- **Build Command**: `just nixpi` to build SD card image
- **Kernel**: Latest Linux kernel for best hardware support

## Technical Details

- Added aarch64-linux to flake systems
- Created hosts/nixpi/default.nix with SD image configuration
- Registered nixpi in hosts/default.nix with raspberry-pi-4 hardware module
- Added nixpi SSH host key to secrets/secrets.nix
- Added justfile command with flashing instructions

## Build Requirements

**Important**: This image must be built on a Linux host (freya or thor) due to cross-compilation limitations from Darwin to aarch64-linux.

## Test Plan

- [x] `just check` passes with zero errors/warnings
- [x] Configuration evaluates correctly
- [x] SD image output path validates
- [ ] Build on Linux host (freya/thor)
- [ ] Flash to SD card and boot test
- [ ] Verify Tailscale auto-connect
- [ ] Confirm SSH access

## Flashing Instructions

```bash
# Build (on Linux host)
just nixpi

# Flash to SD card
zstd -d result/sd-image/*.img.zst -c | sudo dd of=/dev/sdX bs=4M status=progress
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)