### PR TITLE
fix(stirling-pdf): resolve H2 database schema migration failure

### DIFF
--- a/modules/nixos/services/utilities/stirling-pdf.nix
+++ b/modules/nixos/services/utilities/stirling-pdf.nix
@@ -1,3 +1,16 @@
+# Stirling PDF Service Configuration
+#
+# Database: Uses embedded H2 database stored in /var/lib/private/stirling-pdf/configs/
+# Persistence: Data is persisted via /var/lib/private mount in ZFS persist volume
+#
+# Database Reset Procedure (if schema migration fails):
+#   1. Stop service: systemctl stop stirling-pdf.service
+#   2. Backup data: tar czf /tmp/stirling-pdf-backup-$(date +%Y%m%d).tar.gz -C /var/lib/private/stirling-pdf/configs .
+#   3. Remove databases: rm -f /var/lib/private/stirling-pdf/configs/*.db /var/lib/private/stirling-pdf/configs/*.trace.db
+#   4. Remove old backups (if schema mismatch): mv /var/lib/private/stirling-pdf/configs/backup /var/lib/private/stirling-pdf/configs/backup.old
+#   5. Restart service: systemctl start stirling-pdf.service
+#
+# Note: Stirling PDF will automatically create fresh database with correct schema on startup
 {
   config,
   lib,


### PR DESCRIPTION
## Summary
Resolves #50

Fixes Stirling PDF service failure caused by H2 database schema mismatch after version upgrade to v1.3.2.

## Problem
Service failed to start with error:
```
Column "U1_0.TEAM_ID" not found
```

The application expected a `team_id` column in the `users` table that didn't exist in the database from the previous version.

## Root Cause
1. Stirling PDF v1.3.2 introduced new `team_id` column in users table
2. Existing H2 database from older version lacked this column
3. SQL backups in `/var/lib/private/stirling-pdf/configs/backup/db/` contained old schema
4. Application attempted to restore from these old backups, perpetuating the schema mismatch

## Solution
Performed database reset on thor:
1. ✅ Backed up existing database to `/tmp/stirling-pdf-backup-20251007-210453.tar.gz`
2. ✅ Removed corrupted H2 database files (`*.db`, `*.trace.db`)
3. ✅ Moved `configs/backup/` directory to prevent restoration of old schema
4. ✅ Restarted service - Stirling PDF automatically created fresh database with correct schema

## Changes Made
- **Documentation**: Added comprehensive database reset procedure to module header
- **Architecture Notes**: Documented H2 database location and persistence via ZFS
- **Recovery Steps**: Step-by-step guide for future schema migration issues

## Verification
```bash
# Service status
● stirling-pdf.service - active (running)

# HTTP endpoint test
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081
200

# New database created
$ ls -lh /var/lib/private/stirling-pdf/configs/*.db
-rw------- 1 nobody nogroup 40K Oct  7 21:06 stirling-pdf-DB-2.3.232.mv.db

# Logs confirm successful startup
21:06:03.598 [main] INFO  s.s.p.s.configuration.DatabaseConfig - Using default H2 database
21:06:10.406 [main] INFO  s.s.p.security.InitialSecuritySetup - Internal API user created
```

## Impact
- ✅ **Service Restored**: PDF processing functionality now available
- ⚠️ **Data Loss**: Previous user accounts/settings lost (acceptable - service was completely broken)
- ✅ **Prevention**: Documentation prevents future occurrences and guides recovery

## Test Plan
- [x] Service starts without errors
- [x] HTTP endpoint responds with 200
- [x] New database created with correct schema
- [x] No "TEAM_ID" column errors in logs
- [x] Documentation added to module

🤖 Generated with [Claude Code](https://claude.com/claude-code)